### PR TITLE
Added default parameter and removed jsonpickle

### DIFF
--- a/Chart.py
+++ b/Chart.py
@@ -29,11 +29,7 @@ class Chart:
 
         return self._labels
 
-    def add_data_entry(self, data, label):
-
-        self.add_data_entry(data, label, "DEFAULT")
-
-    def add_data_entry(self, data, label, data_set):
+    def add_data_entry(self, data, label, data_set="DEFAULT"):
 
         if label not in self._data_entries.keys():
 

--- a/Export.py
+++ b/Export.py
@@ -1,5 +1,4 @@
 import Chart
-import jsonpickle
 
 
 def export_charts(title, desc, charts):
@@ -111,14 +110,6 @@ def write_chart_script(chart):
 
 
     return script
-
-
-def get_chart_json(chart):
-
-    json = '{'\
-           '}'
-
-    return json
 
 # charts = []
 # export()


### PR DESCRIPTION
Assuming the idea of json was abandoned (as jsonpickle was not used anywhere in the files), I've removed get_chart_json and jsonpickle. This may be in error if JSON plans are included in the future. 

Details:
- Replaced redundant definition of Chart.add_data_entry with a default
  parameter
- Removed jsonpickle import and get_chart_json() from Export.py
